### PR TITLE
json不能解析二进制组，需要先utf-8编码。

### DIFF
--- a/src/extractor.py
+++ b/src/extractor.py
@@ -45,8 +45,10 @@ class TopicExtractor(object):
         db = base.init_leveldb(cluster=cluster, topic=topic)
 
         try:
-            self.startPosition = json.loads(db.Get(startKey))
-            self.stopPosition = json.loads(db.Get(endKey))
+            #self.startPosition = json.loads(db.Get(startKey))
+            #self.stopPosition = json.loads(db.Get(endKey))
+            self.startPosition = json.loads(str(db.Get(startKey), encoding="utf-8"))
+            self.stopPosition = json.loads(str(db.Get(endKey), encoding="utf-8"))
 
         except KeyError:
             raise KeyError("No offset is available.")
@@ -67,6 +69,7 @@ class TopicExtractor(object):
 
     def get_progress(self):
         """ 进度条提示 """
+
 
         for partition, items in self.progress.items():
             sys.stdout.write("Partition %s: %s/%s Offsets." % (partition, *items) + "\n")


### PR DESCRIPTION
修改了extractor.py的48、49行。
json不能解析二进制组，需要先utf-8编码。
另外，如果想要足够的精度，那么采样周期必须很短（比如一分钟），请问有没有测试过对kafka集群性能是否有影响。
不知道Kafka集群本身能不能读取到 时间戳-logsize/offset的对应关系，这样就不用单独再维护一套k-v数据库了。
多谢，工具很有用。